### PR TITLE
fix #49 for linux

### DIFF
--- a/app/src/linuxMain/kotlin/de/jonasbroeckmann/nav/utils/Stat.kt
+++ b/app/src/linuxMain/kotlin/de/jonasbroeckmann/nav/utils/Stat.kt
@@ -14,7 +14,7 @@ import kotlin.time.Instant
 actual fun stat(path: Path): StatResult = memScoped {
     val result: stat = alloc()
     set_posix_errno(0)
-    stat(path.toString(), result.ptr)
+    lstat(path.toString(), result.ptr)
     return StatResult.fromErrno() ?: Stat(
         deviceId = result.st_dev,
         serialNumber = result.st_ino,


### PR DESCRIPTION
Symlinks are now correctly recognized. Nav shows them correctly in a different color and with an arrow pointing to the right. (It does not yet show where the symlink points; maybe that should also be added to this PR.)