### PR TITLE
Improve automatic cursor placement

### DIFF
--- a/app/src/commonMain/kotlin/de/jonasbroeckmann/nav/app/App.kt
+++ b/app/src/commonMain/kotlin/de/jonasbroeckmann/nav/app/App.kt
@@ -207,8 +207,9 @@ class App(
             state = state.inQuickMacroMode(false)
         }
         for (action in actions.ordered) {
-            if (!action.matches(state, this)) continue
-            return action.tryPerform(state, this, terminal)
+            if (action.matches(state, this)) {
+                return action.tryPerform(state, this, terminal)
+            }
         }
         val command = state.command
         if (command != null) {

--- a/app/src/commonMain/kotlin/de/jonasbroeckmann/nav/app/State.kt
+++ b/app/src/commonMain/kotlin/de/jonasbroeckmann/nav/app/State.kt
@@ -24,9 +24,12 @@ data class State private constructor(
 ) {
     val filteredItems: List<Entry> by lazy {
         if (filter.isEmpty()) return@lazy items
+        val lowercaseFilter = filter.lowercase()
         items
-            .filter { filter.lowercase() in it.path.name.lowercase() }
-            .sortedByDescending { it.path.name.startsWith(filter) } // intentionally
+            .filter { lowercaseFilter in it.path.name.lowercase() }
+            // TODO replace with scoring algorithm
+            .sortedByDescending { it.path.name.startsWith(filter, ignoreCase = true) }
+            .sortedByDescending { it.path.name.startsWith(filter) }
     }
     val currentEntry: Entry? get() = filteredItems.getOrNull(cursor)
 

--- a/app/src/commonMain/kotlin/de/jonasbroeckmann/nav/app/UI.kt
+++ b/app/src/commonMain/kotlin/de/jonasbroeckmann/nav/app/UI.kt
@@ -350,16 +350,14 @@ class UI(
 
             render(actions.autocompleteFilter)
             render(actions.clearFilter)
-            render(actions.exitMenu)
 
             render(actions.discardCommand)
 
             render(actions.exitCD)
             render(actions.exit)
 
-            if (!state.isMenuOpen) {
-                render(actions.openMenu)
-            }
+            render(actions.openMenu)
+            render(actions.exitMenu)
         }
 
         if (debugMode) {


### PR DESCRIPTION
The cursor now follows the last selected entry as close as possible on changes to the entry list (e.g. filtering, file system).
An exception is made while narrowing the filter where the best possible match is (still) preferred.